### PR TITLE
Remove Rebecca, correct typo in Ryan's name

### DIFF
--- a/content/code-of-conduct.md
+++ b/content/code-of-conduct.md
@@ -99,12 +99,11 @@ Tech members or the general public.
 the incident response team can be reached by directly messaging anyone on the
 list below:
 
-- Rebecca Skinner (@rebecca.skinner)
 - Becca Stevens (@beccastevens)
 - Tristan Blease (@thetristan)
 - Keith Brown (@hellmark)
 - Craig Buchek (@craigbuchek)
-- Ryan Colmean (@ryuhhnn)
+- Ryan Coleman (@ryuhhnn)
 
 ## Source
 

--- a/content/member-handbook.md
+++ b/content/member-handbook.md
@@ -152,11 +152,10 @@ That said, here are some things we might do, in rough order of severity:
 The moderation team is here to help you and to guide conversation towards good places.
 If you have any problems, use the `/admin` command and someone will respond soon.
 
-* Rebecca Skinner (@rebecca.skinner) - Admin
-* Becca Stevens (@beccastevens) - Moderator
-* Tristan Blease (@thetristan) - Moderator
-* Keith Brown (@hellmark) - Moderator
-* Craig Buchek (@craigbuchek) - Moderator
-* Ryan Colmean (@ryuhhnn) - Moderator
+* Becca Stevens (@beccastevens)
+* Tristan Blease (@thetristan)
+* Keith Brown (@hellmark)
+* Craig Buchek (@craigbuchek)
+* Ryan Coleman (@ryuhhnn)
 
 Moderators are chosen by the admins for being helpful in community spaces.


### PR DESCRIPTION
Updates to the mod lists. I'm proposing we remove the label identifying folks as admins/moderators as it doesn't make any effective difference for folks in the community that we interact with.

FYI @beccastevens @booch et al