### PR TITLE
Fix code-of-conduct link

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,7 +319,7 @@
                             Recurse Center&rsquo;s social rules</a>.
                         Specifically: no feigning surprise, no well-actually&rsquo;s, no back-seat driving, and no subtle
                         -isms.</p>
-                    <p>In addition to the above, please read <a href="http://stl-tech.github.io/code-of-conduct/">Code of
+                    <p>In addition to the above, please read <a href="#code-of-conduct">Code of
                             Conduct</a>.
                         The behaviors listed there are used as bright lines for moderation and removal.</p>
                     <p>Finally, the STL Tech community is not a place for hate speech or hate groups.


### PR DESCRIPTION
Was pointing to an invalid (or perhaps non-public) wiki page. Now points back up in this document.